### PR TITLE
Define arg alias and boolean types.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,14 @@ const usage = `  Usage: get-graphql-schema ENDPOINT_URL > schema.graphql
 `
 
 async function main() {
-  const argv = minimist(process.argv.slice(2))
+  const argv = minimist(process.argv.slice(2), {
+    alias: {
+      h: 'header',
+      j: 'json',
+      v: 'version'
+    },
+    boolean: ['json', 'version']
+  })
 
   if (argv._.length < 1) {
     console.log(usage)


### PR DESCRIPTION
Hello,

**Motivation:**
Without defining which args are boolean the endpoint url can accidentally be picked up as a value.

**Example:** 
`node dist/index.js -j http://sym-graphql.docker.local/graphql > symfony.json`

**Solution**
Define the boolean types; and alias to keep it tidy.

Thanks for a wonderful library, really helpful for debugging schemas / stitching.